### PR TITLE
Change: add recommend markdownlint extension for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["davidanson.vscode-markdownlint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.rulers": [
+    {
+      "column": 120
+    }
+  ],
+  "editor.tabSize": 2
+}


### PR DESCRIPTION
This PR will add `davidanson.vscode-markdownlint` to the extensions recommended by VSCode to help with linting markdown files. When opening the repo, users will be presented with the following message where they can opt-in to installation:

![image](https://github.com/user-attachments/assets/65091e76-cb74-42bf-899b-2585280b1689)

This extension is provided by a verified publisher, more details can be found on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint).

Additionally, I added a ruler at col 120 and sets tab size to 2 spaces to aid in markdown editing.