### PR TITLE
Add Visual Studio 2022 Build Guide

### DIFF
--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -19,18 +19,18 @@ For build using solutions and more advanced build configurations, see below.
 
 ## Steps
 
-### 1. prepare the project
+### 1. Prepare the project
 
 - Open the cloned folder in Visual Studio 2022.
-- Wait for Visual Studio to generate the necessary cmake files.
+- Wait for Visual Studio to generate the necessary CMake files.
 
 ### 2. Build the Project
 
 - Select the appropriate build configuration:
-- `Build Windows build` for a release build.
-- `Build Windows Debug build` for a debug build.
-- `Build Windows Internal build` for an internal build.
-- `Build Windows Profile build` for a profile build.
+  - `Build Windows build` for a release build.
+  - `Build Windows Debug build` for a debug build.
+  - `Build Windows Internal build` for an internal build.
+  - `Build Windows Profile build` for a profile build.
 
 >[!TIP]
 > For more information on the different build configurations, see the [Build Configurations](build_configurations.md)
@@ -56,13 +56,14 @@ page.
 
 ### Build using command line
 
-You need to install cmake and ninja to build the project from the command line.
+You need to install [CMake](https://cmake.org/download/) and [Ninja](https://github.com/ninja-build/ninja/releases)
+to build the project from the command line.
 
 - In the developer command prompt, open the settings to add the x86 environment terminal.
 
 >[!Tip]
-> Alternatively, you can open the x86 Native Tools Command Prompt from the start menu, and navigate to the project
-   directory in the terminal then run the commands below.
+> Alternatively, you can open the "x86 Native Tools Command Prompt for VS 2022" from the start menu,
+> and navigate to the project directory in the terminal then run the commands below.
   
 - In the pop-up window, click on the 'Add' and set the following: (assuming default installation path)
   - Name: `x86 Native Tools Command Prompt`

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -1,62 +1,87 @@
-# Building and Compiling C&C Generals on Visual Studio 2022
+# Building and Compiling C&C Generals & Zero Hour on Visual Studio 2022
+
+This guide will walk you through the process of basic setup and compilation of the C&C Generals and Zero Hour source
+code using Visual Studio 2022.
+For build using solutions and more advanced build configurations, see below.
 
 ## Prerequisites
 
-1. **Install Visual Studio 2022**
-    - Ensure that the necessary C++ development components, including MFC, are installed.
+1. **Visual Studio 2022**
 
-2. **Obtain the C&C Generals Source Code**
-    - Clone or download the source code repository: [TheSuperHackers - GeneralsGameCode](https://github.com/TheSuperHackers/GeneralsGameCode.git).
+- Ensure that the necessary C++ development components, **including MFC**, are installed.
 
-3. **Install C&C Generals (Steam Version)**
-    - The game installation is required to access the necessary asset files.
+>[!WARNING]
+> You must have the MFC components installed to compile the source code.
+<!-- markdownlint-disable-next-line -->
+2. **Obtain the Source Code (Step 1)**
+    - Clone or download the source code
+      repository: [TheSuperHackers - GeneralsGameCode](https://github.com/TheSuperHackers/GeneralsGameCode.git).
 
-## Build Steps
+## Steps
 
-### 1. Open the Project in Visual Studio 2022
+### 1. Clone and prepare the project
 
-- Launch Visual Studio 2022 and open the solution file `Code/RTS.sln`.
+- Clone the repository to your local machine.
+- Open the folder in Visual Studio 2022.
+- Wait for Visual Studio to generate the necessary cmake files.
 
-### 2. Select and Compile the Required Projects
+### 2. Build the Project
 
-- In the **Solution Explorer**, locate the following projects:
-  - `RTS`
-  - `WorldBuilder`
-- Right-click each project and select **Build**.
-- Ensure the build process completes without errors.
+- Select you favorite build configuration:
+- `Build Windows build` for a release build.
+- `Build Windows Debug build` for a debug build.
+- `Build Windows Internal build` for an internal build.
+- `Build Windows Profile build` for a profile build.
 
-### 3. Copy Required Game Files from Steam
+>[!TIP]
+> For more information on the different build configurations, see the [Build Configurations](build_configurations.md)
+page.
 
-- Navigate to your C&C Generals Steam installation directory, typically:
+- Select the target you want to build:
+- `generalsv.exe` to build the base Generals.
+- `generalszh.exe` to build Zero Hour.
 
-  ``` text
-  C:\Program Files (x86)\Steam\steamapps\common\Command and Conquer Generals Zero Hour\
-  ```
+- Build the project by clicking on the `Build` menu and selecting `Build`.
+- The compiled executable will be placed in the `build/<win32 build type>/<game name (Generals/GeneralsMD)>/<build configuration>`
+  folder. Example: `build/win32dgb/GeneralsMD/Debug`
+- Install the game executable in the game directory by clicking on the `Install` in `Build` menu. This will copy the
+  executable to the retail game directory.
 
-- Copy all necessary `.BIG` files into the `Run` folder of your compiled project:
+## Additional Steps
 
-  ``` text
-  EnglishZH.big
-  INIZH.big
-  SpeechZH.big
-  W3DZH.big
-  (Other required files)
-  ```
+### Build through Cmake target view
 
-- Copy the entire `Data` folder to the `Run` folder as well.
+- In the Solution Explorer, click on 'switch view' and select 'CMake Targets View'.
+- Expand the 'Genzh' project and right-click on the target you want to build.
+- Select 'Build' to compile the target.
 
-### 4. Configure Paths Correctly
+### Build using command line
 
-- Ensure that the `Run` folder within your build directory contains all required game assets.
-- If necessary, configure the **working directory** in Visual Studio:
-    1. Right-click on the `RTS` project.
-    2. Navigate to **Properties** → **Debugging**.
-    3. Set `Working Directory` to your `Run` folder.
+You need to install cmake and ninja to build the project from the command line.
 
-### 5. Run the Game or World Builder
+- In the developer command prompt, open the settings to add the x86 environment terminal.
 
-- After compiling, navigate to the `Run` folder.
-- Launch `RTSD.exe` or `worldbuilder.exe`.
+>[!Tip]
+> Alternatively, you can open the x86 Native Tools Command Prompt from the start menu, and navigate to the project
+   directory in the terminal then run the commands below.
+  
+- In the pop-up window, click on the 'Add' and set the following: (assuming default installation path)
+  - Name: `x86 Native Tools Command Prompt`
+  - Shell Location: `C:\Windows\System32\cmd.exe`
+  - Arguments: `/k "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"`
+- Now you can open the new terminal from the terminal dropdown list.
+- Run the following commands to build the project:
+- Choose the build configuration:
+  - `cmake --workflow --preset win32` for Release build.
+  - `cmake --workflow --preset win32dgb` for Debug build.
+  - `cmake --workflow --preset win32int` for Internal build.
+  - `cmake --workflow --preset win32prof` for Profile build.
+- Install the game executable in the game directory (assuming that the build was successful):
+  - `cmake --install build/<preset name>`
+- To build a specific target:
+  - Run `cmake --build build/<preset name> --target <target name>`
+  - Example: `cmake --build build/win32 --target z_generals`
+  - Or: `cmake --build build/win32 --target g_generals`
 
 ## Troubleshooting
 

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -5,7 +5,7 @@ code using Visual Studio 2022.
 For build using solutions and more advanced build configurations, see below.
 
 - [Prerequisites](#prerequisites)
-- [Build through Visual Studio 2022](#1-prepare-the-project)
+- [Build through Visual Studio 2022](#build-through-visual-studio-2022)
 - [Build through CMake target view](#build-through-cmake-target-view)
 - [Build using command line](#build-using-command-line)
 - [Build using solutions](#build-with-solutions)
@@ -27,7 +27,9 @@ For build using solutions and more advanced build configurations, see below.
     - Clone or download the source code
       repository: [TheSuperHackers - GeneralsGameCode](https://github.com/TheSuperHackers/GeneralsGameCode.git).
 
-## Steps
+---
+
+## Build through Visual Studio 2022
 
 ### 1. Prepare the project
 
@@ -59,9 +61,9 @@ page.
 - Install the game executable in the game directory by clicking on the `Install` in `Build` menu. This will copy the
   executable to the retail game directory.
 
-## Additional Steps
+---
 
-### Build through CMake target view
+## Build through CMake target view
 
 - In the Solution Explorer, click on 'switch view' and select 'CMake Targets View'.
 - Expand the 'Genzh' project and right-click on the target you want to build.
@@ -69,7 +71,9 @@ page.
 
 ![image](https://github.com/user-attachments/assets/adb296b6-ae05-4a23-9aa7-2a9c56b9e8e9)
 
-### Build using command line
+---
+
+## Build using command line
 
 You need to install [CMake](https://cmake.org/download/) and [Ninja](https://github.com/ninja-build/ninja/releases)
 to build the project from the command line.
@@ -85,7 +89,7 @@ to build the project from the command line.
 > Alternatively, you can skip the terminal setup and simply open the "x86 Native Tools Command Prompt for
 > VS 2022" from the Start menu. Once opened, navigate to the project directory in the terminal and proceed
 > to run the commands below.
-  
+<!-- markdownlint-disable-next-line -->
 - #### 1. **Release Build**
 
   - **Choose the build configuration:**
@@ -109,12 +113,18 @@ to build the project from the command line.
   - Example: `cmake --build build/win32dgb --target z_generals`
   - Or: `cmake --build build/win32int --target g_generals`
 
-### Build with Solutions
+For more CMake options, see the [CMake Guide](cmake_guide).
+
+---
+
+## Build with Solutions
 
 - Generate the Visual Studio solution with the appropriate preset (see above):
 - Run `cmake --preset win32 -G "Visual Studio 17 2022" -A Win32`
 - Navigate to the `build/win32` folder and open the generated solution file.
 - Build the project using the Visual Studio interface.
+
+---
 
 ## Troubleshooting
 

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -4,6 +4,12 @@ This guide will walk you through the process of basic setup and compilation of t
 code using Visual Studio 2022.
 For build using solutions and more advanced build configurations, see below.
 
+- [Prerequisites](#prerequisites)
+- [Build through Visual Studio 2022](#1-prepare-the-project)
+- [Build through CMake target view](#build-through-cmake-target-view)
+- [Build using command line](#build-using-command-line)
+- [Troubleshooting](#troubleshooting)
+
 ## Prerequisites
 
 1. **Visual Studio 2022**
@@ -41,8 +47,7 @@ page.
   - `generalszh.exe` to build Zero Hour.
 
 - Build the project by clicking on the `Build` menu and selecting `Build`.
-- The compiled executable will be placed in the `build/<win32 build type>/<game name (Generals/GeneralsMD)>/<build configuration>`
-  folder. Example: `build/win32dgb/GeneralsMD/Debug`
+- The compiled executable will be placed in the build folder. Example: `build/win32dgb/GeneralsMD/Debug`
 - Install the game executable in the game directory by clicking on the `Install` in `Build` menu. This will copy the
   executable to the retail game directory.
 
@@ -60,31 +65,45 @@ You need to install [CMake](https://cmake.org/download/) and [Ninja](https://git
 to build the project from the command line.
 
 - In the developer command prompt, open the settings to add the x86 environment terminal.
-
->[!Tip]
-> Alternatively, you can open the "x86 Native Tools Command Prompt for VS 2022" from the start menu,
-> and navigate to the project directory in the terminal then run the commands below.
-  
 - In the pop-up window, click on the 'Add' and set the following: (assuming default installation path)
   - Name: `x86 Native Tools Command Prompt`
   - Shell Location: `C:\Windows\System32\cmd.exe`
   - Arguments: `/k "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"`
 - Now you can open the new terminal from the terminal dropdown list.
-- Run the following commands to build the project:
-- Choose the build configuration:
-  - `cmake --workflow --preset win32` for Release build.
-  - `cmake --workflow --preset win32dgb` for Debug build.
-  - `cmake --workflow --preset win32int` for Internal build.
-  - `cmake --workflow --preset win32prof` for Profile build.
-- Install the game executable in the game directory (assuming that the build was successful):
-  - `cmake --install build/<preset name>`
-- To build a specific target:
+
+>[!Tip]
+> Alternatively, you can skip the terminal setup and simply open the "x86 Native Tools Command Prompt for
+> VS 2022" from the Start menu. Once opened, navigate to the project directory in the terminal and proceed
+> to run the commands below.
+  
+
+- #### 1. **Release Build**
+
+  - **Choose the build configuration:**
+    - `cmake --workflow --preset win32` for Release build.
+
+  - **Install the game executable in the game directory (assuming the build was successful):**
+    - `cmake --install build/win32 --config Release`
+
+- #### 2. **Development and Debug Builds**
+
+  - **Choose the build configuration:**
+    - `cmake --workflow --preset win32dgb` for Debug build.
+    - `cmake --workflow --preset win32int` for Internal build.
+    - `cmake --workflow --preset win32prof` for Profile build.
+
+  - **Install the game executable in the game directory (assuming the build was successful):**
+    - `cmake --install build/<preset name>`
+
+
+- **To build a specific target:**
   - Run `cmake --build build/<preset name> --target <target name>`
-  - Example: `cmake --build build/win32 --target z_generals`
-  - Or: `cmake --build build/win32 --target g_generals`
+  - Example: `cmake --build build/win32dgb --target z_generals`
+  - Or: `cmake --build build/win32int --target g_generals`
 
 ## Troubleshooting
 
 - **Missing DLLs?** Ensure that all required dependencies are installed.
 - **Game not launching?** Verify that all necessary `.BIG` files are correctly placed.
-- **Build errors?** Check Visual Studio settings and dependencies for any issues.
+- **Build errors?** Check Visual Studio settings and dependencies for any issues or delete the `build` folder and try
+  building again.

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -8,6 +8,7 @@ For build using solutions and more advanced build configurations, see below.
 - [Build through Visual Studio 2022](#1-prepare-the-project)
 - [Build through CMake target view](#build-through-cmake-target-view)
 - [Build using command line](#build-using-command-line)
+- [Build using solutions](#build-with-solutions)
 - [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
@@ -76,7 +77,6 @@ to build the project from the command line.
 > VS 2022" from the Start menu. Once opened, navigate to the project directory in the terminal and proceed
 > to run the commands below.
   
-
 - #### 1. **Release Build**
 
   - **Choose the build configuration:**
@@ -95,11 +95,17 @@ to build the project from the command line.
   - **Install the game executable in the game directory (assuming the build was successful):**
     - `cmake --install build/<preset name>`
 
-
 - **To build a specific target:**
   - Run `cmake --build build/<preset name> --target <target name>`
   - Example: `cmake --build build/win32dgb --target z_generals`
   - Or: `cmake --build build/win32int --target g_generals`
+
+### Build with Solutions
+
+- Generate the Visual Studio solution with the appropriate preset (see above):
+- Run `cmake --preset win32 -G "Visual Studio 17 2022" -A Win32`
+- Navigate to the `build/win32` folder and open the generated solution file.
+- Build the project using the Visual Studio interface.
 
 ## Troubleshooting
 

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -18,7 +18,10 @@ For build using solutions and more advanced build configurations, see below.
 - Ensure that the necessary C++ development components, **including MFC**, are installed.
 
 >[!NOTE]
-> You must have the MFC components installed to compile the source code.
+> You must have the MFC components installed to compile the source code. You can find it in Visual Studio Installer.
+>
+> ![image](https://github.com/user-attachments/assets/cdabd4d9-f291-4833-8a63-704654a43780)
+
 <!-- markdownlint-disable-next-line -->
 2. **Obtain the Source Code**
     - Clone or download the source code
@@ -39,6 +42,8 @@ For build using solutions and more advanced build configurations, see below.
   - `Build Windows Internal build` for an internal build.
   - `Build Windows Profile build` for a profile build.
 
+![image](https://github.com/user-attachments/assets/2bc0aa26-3342-4aac-ae5b-6cf91db21214)
+
 >[!TIP]
 > For more information on the different build configurations, see the [Build Configurations](build_configurations.md)
 page.
@@ -46,6 +51,8 @@ page.
 - Select the target you want to build:
   - `generalsv.exe` to build the base Generals.
   - `generalszh.exe` to build Zero Hour.
+
+![image](https://github.com/user-attachments/assets/37d59b79-77fc-4797-bbab-be385dd654da)
 
 - Build the project by clicking on the `Build` menu and selecting `Build`.
 - The compiled executable will be placed in the build folder. Example: `build/win32dgb/GeneralsMD/Debug`
@@ -59,6 +66,8 @@ page.
 - In the Solution Explorer, click on 'switch view' and select 'CMake Targets View'.
 - Expand the 'Genzh' project and right-click on the target you want to build.
 - Select 'Build' to compile the target.
+
+![image](https://github.com/user-attachments/assets/adb296b6-ae05-4a23-9aa7-2a9c56b9e8e9)
 
 ### Build using command line
 

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -1,0 +1,65 @@
+# Building and Compiling C&C Generals on Visual Studio 2022
+
+## Prerequisites
+
+1. **Install Visual Studio 2022**
+    - Ensure that the necessary C++ development components, including MFC, are installed.
+
+2. **Obtain the C&C Generals Source Code**
+    - Clone or download the source code repository: [TheSuperHackers - GeneralsGameCode](https://github.com/TheSuperHackers/GeneralsGameCode.git).
+
+3. **Install C&C Generals (Steam Version)**
+    - The game installation is required to access the necessary asset files.
+
+## Build Steps
+
+### 1. Open the Project in Visual Studio 2022
+
+- Launch Visual Studio 2022 and open the solution file `Code/RTS.sln`.
+
+### 2. Select and Compile the Required Projects
+
+- In the **Solution Explorer**, locate the following projects:
+  - `RTS`
+  - `WorldBuilder`
+- Right-click each project and select **Build**.
+- Ensure the build process completes without errors.
+
+### 3. Copy Required Game Files from Steam
+
+- Navigate to your C&C Generals Steam installation directory, typically:
+
+  ``` text
+  C:\Program Files (x86)\Steam\steamapps\common\Command and Conquer Generals Zero Hour\
+  ```
+
+- Copy all necessary `.BIG` files into the `Run` folder of your compiled project:
+
+  ``` text
+  EnglishZH.big
+  INIZH.big
+  SpeechZH.big
+  W3DZH.big
+  (Other required files)
+  ```
+
+- Copy the entire `Data` folder to the `Run` folder as well.
+
+### 4. Configure Paths Correctly
+
+- Ensure that the `Run` folder within your build directory contains all required game assets.
+- If necessary, configure the **working directory** in Visual Studio:
+    1. Right-click on the `RTS` project.
+    2. Navigate to **Properties** → **Debugging**.
+    3. Set `Working Directory` to your `Run` folder.
+
+### 5. Run the Game or World Builder
+
+- After compiling, navigate to the `Run` folder.
+- Launch `RTSD.exe` or `worldbuilder.exe`.
+
+## Troubleshooting
+
+- **Missing DLLs?** Ensure that all required dependencies are installed.
+- **Game not launching?** Verify that all necessary `.BIG` files are correctly placed.
+- **Build errors?** Check Visual Studio settings and dependencies for any issues.

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -10,19 +10,18 @@ For build using solutions and more advanced build configurations, see below.
 
 - Ensure that the necessary C++ development components, **including MFC**, are installed.
 
->[!WARNING]
+>[!NOTE]
 > You must have the MFC components installed to compile the source code.
 <!-- markdownlint-disable-next-line -->
-2. **Obtain the Source Code (Step 1)**
+2. **Obtain the Source Code**
     - Clone or download the source code
       repository: [TheSuperHackers - GeneralsGameCode](https://github.com/TheSuperHackers/GeneralsGameCode.git).
 
 ## Steps
 
-### 1. Clone and prepare the project
+### 1. prepare the project
 
-- Clone the repository to your local machine.
-- Open the folder in Visual Studio 2022.
+- Open the cloned folder in Visual Studio 2022.
 - Wait for Visual Studio to generate the necessary cmake files.
 
 ### 2. Build the Project
@@ -38,8 +37,8 @@ For build using solutions and more advanced build configurations, see below.
 page.
 
 - Select the target you want to build:
-- `generalsv.exe` to build the base Generals.
-- `generalszh.exe` to build Zero Hour.
+  - `generalsv.exe` to build the base Generals.
+  - `generalszh.exe` to build Zero Hour.
 
 - Build the project by clicking on the `Build` menu and selecting `Build`.
 - The compiled executable will be placed in the `build/<win32 build type>/<game name (Generals/GeneralsMD)>/<build configuration>`
@@ -49,7 +48,7 @@ page.
 
 ## Additional Steps
 
-### Build through Cmake target view
+### Build through CMake target view
 
 - In the Solution Explorer, click on 'switch view' and select 'CMake Targets View'.
 - Expand the 'Genzh' project and right-click on the target you want to build.

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -26,7 +26,7 @@ For build using solutions and more advanced build configurations, see below.
 
 ### 2. Build the Project
 
-- Select you favorite build configuration:
+- Select the appropriate build configuration:
 - `Build Windows build` for a release build.
 - `Build Windows Debug build` for a debug build.
 - `Build Windows Internal build` for an internal build.


### PR DESCRIPTION
Adds a build guide for VS2022.
- This is compatible after merging https://github.com/TheSuperHackers/GeneralsGameCode/pull/498

