### PR TITLE
Fix all markdownlint errors outside of build_with_msvc6.md

### DIFF
--- a/Asset/Localization/localization_contribution.md
+++ b/Asset/Localization/localization_contribution.md
@@ -93,9 +93,9 @@ patch.
 translations should be based on it.
 
 2.7 We are currently reorganizing the Super Patch GitHub page. If you want to submit your localization edit, please
-create a discussion [here](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions). We will fix this situation
-soon, so you can post it yourself. You can check the situation and
-updates [here](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions/2637).
+create a discussion on the [GeneralsGamePatch discussions page](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions).
+We will fix this situation soon, so you can post it yourself. You can check the situation and
+updates on the [reorganization discussion](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions/2637).
 
 From line - 59939 `DIALOGEVENT:EvaChina_AllyUnderAttackSubtitle` until line - 96720
 `DIALOGEVENT:UnitDescriptXUSA037Subtitle` you can find Voiceover text used in game Dialogues. We have 3 official game
@@ -137,9 +137,9 @@ edits.
 
 3.4 **Submitting Your Localization**: We are currently in the process of reorganizing the Super Patch GitHub page. If
 you want to submit your localization edit, please create a
-discussion [here](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions). We will resolve this situation soon
-so you can post it yourself. You can check the situation and
-updates [here](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions/2637).
+discussion on the [GeneralsGamePatch discussions page](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions).
+We will resolve this situation soon so you can post it yourself. You can check the situation and
+updates on the [reorganization discussion](https://github.com/TheSuperHackers/GeneralsGamePatch/discussions/2637).
 
 ## 4. Testing and Verifying Changes in the Game
 

--- a/Asset/Patch/contribution.md
+++ b/Asset/Patch/contribution.md
@@ -141,7 +141,7 @@ To write a link, use the following format:
 ```
 
 Some keywords are interpreted by GitHub. Read about
-it [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
+it in the [GitHub documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
 
 The text body continues with a description of the change in appropriate detail. This serves to educate reviewers and
 visitors to get a good understanding of the change without the need to study and understand the associated changed

--- a/SourceCode/Debug/replay_testing.md
+++ b/SourceCode/Debug/replay_testing.md
@@ -9,7 +9,7 @@ This makes replays an excellent tool for testing the compatibility and accuracy 
 To perform a test using a replay, use the following steps:
 
 1. Gather previously saved replays of matches played on a known-working version of the game. These replays act as a
-benchmark for testing. A prepared set of test replays can be found [here](#how-to-verify-the-game).
+benchmark for testing. A prepared set of test replays can be found in the [verification section](#how-to-verify-the-game).
 
 2. Copy the replay file into `Documents\Command and Conquer Generals Data\Replays` for _Generals_ replays
 and `Documents\Command and Conquer Generals Zero Hour Data\Replays` for _Zero Hour_ replays.


### PR DESCRIPTION
I fixed all the markdownlint errors except for those in `build_with_msvc6.md`, as I addressed them in #48.

The errors were MD059/descriptive-link-text violations