### PR TITLE
Removed all mentions of the Internal CMake Build Profile and update CMake preset names

### DIFF
--- a/SourceCode/Builds/build_configuration.md
+++ b/SourceCode/Builds/build_configuration.md
@@ -41,25 +41,7 @@ There are four main build configurations in the project, each designed for diffe
 
 - **Use Case:** Used during development for debugging and resolving issues in the code.
 
-### 3. **Internal (O2, _INTERNAL)**
-
-- **Purpose:** The internal configuration is used for internal development purposes, offering optimization and some
-  debugging features to help developers while maintaining performance.
-- **Features:**
-  - Combines optimization (`/O2`) for performance with limited debugging options.
-  - Suitable for internal testing and development, where performance is important, but some debugging features are
-    still needed.
-
-- **Compiler Flags:**
-  - `/O2`: Optimization for speed.
-  - `/D "_INTERNAL"`: Defines the internal build configuration.
-  - `/D "NDEBUG"`: Disables debugging in the final build.
-  - `/Zi`: Generates debugging information.
-
-- **Use Case:** Used for internal builds when developers need optimized performance but still want some debugging tools
-  available.
-
-### 4. **Profile (O2, IG_DEBUG_STACKTRACE, _RELEASE, _PROFILE)**
+### 3. **Profile (O2, IG_DEBUG_STACKTRACE, _RELEASE, _PROFILE)**
 
 - **Purpose:** The profile configuration is used for performance profiling and optimization. It is designed to help
   developers analyze performance bottlenecks and gather performance data.
@@ -94,9 +76,7 @@ Below is a list of the key compiler flags used across different configurations:
 - **`/D "_DEBUG"`**: Defines the build as a debug version, enabling debugging-specific features in the code.
 - **`/D "_RELEASE"`**: Defines the build as a release version, disabling debugging features and optimizing for
   performance.
-- **`/D "_INTERNAL"`**: Marks the build as an internal version, which may include some debugging information while still
-  being optimized for performance.
-- **`/D "NDEBUG"`**: Disables debugging code, typically used in release and internal builds.
+- **`/D "NDEBUG"`**: Disables debugging code, typically used in release builds.
 
 ### Profiling Flags
 
@@ -121,7 +101,5 @@ Below is a list of the key compiler flags used across different configurations:
   is optimized for performance with no debugging overhead.
 - **Debug:** Use this configuration during development when you need to debug issues. It disables optimizations and
   includes debugging information.
-- **Internal:** Use this configuration for internal builds where you need some debugging features but still require
-  optimized performance.
 - **Profile:** Use this configuration when analyzing the performance of the game. It helps identify bottlenecks and
   areas that can be optimized further.

--- a/SourceCode/Builds/build_guides.md
+++ b/SourceCode/Builds/build_guides.md
@@ -7,8 +7,7 @@ guides cover different environments, configurations, and setups for building the
 ## Build Configurations Overview
 
 Before diving into the build guides, it's important to understand the different build configurations used in the
-project. These configurations dictate how the project is built, whether for debugging, profiling, release, or
-development purposes. Some common configurations include:
+project. These configurations dictate how the project is built, whether for debugging, profiling or release.
 
 - **Release:** Optimized for end-users, providing a smaller, faster executable with no debugging information.
 - **Debug:** Includes debugging information, making it easier to trace and debug the code, but without optimization to

--- a/SourceCode/Builds/build_guides.md
+++ b/SourceCode/Builds/build_guides.md
@@ -7,14 +7,12 @@ guides cover different environments, configurations, and setups for building the
 ## Build Configurations Overview
 
 Before diving into the build guides, it's important to understand the different build configurations used in the
-project. These configurations dictate how the project is built, whether for debugging, profiling, release, or internal
+project. These configurations dictate how the project is built, whether for debugging, profiling, release, or
 development purposes. Some common configurations include:
 
 - **Release:** Optimized for end-users, providing a smaller, faster executable with no debugging information.
 - **Debug:** Includes debugging information, making it easier to trace and debug the code, but without optimization to
   ensure ease of debugging.
-- **Internal:** Includes debugging information and optimizations, used primarily by developers for testing and internal
-  purposes.
 - **Profile:** Used for performance profiling, with optimizations enabled and additional debugging options to collect
   profiling data.
 

--- a/SourceCode/Builds/build_with_clion_vc6_toolchain.md
+++ b/SourceCode/Builds/build_with_clion_vc6_toolchain.md
@@ -54,7 +54,6 @@ compatibility with the original compiler from the game's development era. To com
 1. In the CMake profiles, enable the profiles you want to use. The available workflow presets are:
    - `vc6` - Release build
    - `vc6-debug` - Debug build
-   - `vc6-internal` - Internal build
    - `vc6-profile` - Profile build
 
    For detailed information about each build configuration and their specific purposes, see the [Build Configurations Overview](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_configuration).

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -61,7 +61,7 @@ page.
 ![image](https://github.com/user-attachments/assets/37d59b79-77fc-4797-bbab-be385dd654da)
 
 - Build the project by clicking on the `Build` menu and selecting `Build`.
-- The compiled executable will be placed in the build folder. Example: `build/win32dgb/GeneralsMD/Debug`
+- The compiled executable will be placed in the build folder. Example: `build/win32-debug/GeneralsMD/Debug`
 - Install the game executable in the game directory by clicking on the `Install` in `Build` menu. This will copy the
   executable to the retail game directory.
 
@@ -105,16 +105,16 @@ to build the project from the command line.
 - #### 2. **Development and Debug Builds**
 
   - **Choose the build configuration:**
-    - `cmake --workflow --preset win32dgb` for Debug build.
-    - `cmake --workflow --preset win32prof` for Profile build.
+    - `cmake --workflow --preset win32-debug` for Debug build.
+    - `cmake --workflow --preset win32-profile` for Profile build.
 
   - **Install the game executable in the game directory (assuming the build was successful):**
     - `cmake --install build/<preset name>`
 
 - **To build a specific target:**
   - Run `cmake --build build/<preset name> --target <target name>`
-  - Example: `cmake --build build/win32dgb --target z_generals`
-  - Or: `cmake --build build/win32prof --target g_generals`
+  - Example: `cmake --build build/win32-debug --target z_generals`
+  - Or: `cmake --build build/win32-profile --target g_generals`
 
 For more CMake options, see the [CMake Guide](cmake_guide).
 

--- a/SourceCode/Builds/build_with_msvc22.md
+++ b/SourceCode/Builds/build_with_msvc22.md
@@ -43,11 +43,9 @@ For build using solutions and more advanced build configurations, see below.
 - Select the appropriate build configuration:
   - `Build Windows 32bit Release` for a release build.
   - `Build Windows 32bit Debug` for a debug build.
-  - `Build Windows 32bit Internal` for an internal build.
   - `Build Windows 32bit Profile` for a profile build.
   - `Build Windows 32bit VCPKG Release` for a release build with the VCPKG package manager.
   - `Build Windows 32bit VCPKG Debug` for a debug build with the VCPKG package manager.
-  - `Build Windows 32bit VCPKG Internal` for an internal build with the VCPKG package manager.
   - `Build Windows 32bit VCPKG Profile` for a profile build with the VCPKG package manager.
 
 ![Build options](https://github.com/TheSuperHackers/GeneralsWiki/raw/refs/heads/main/SourceCode/Builds/files/buildoptions.jpg)
@@ -108,7 +106,6 @@ to build the project from the command line.
 
   - **Choose the build configuration:**
     - `cmake --workflow --preset win32dgb` for Debug build.
-    - `cmake --workflow --preset win32int` for Internal build.
     - `cmake --workflow --preset win32prof` for Profile build.
 
   - **Install the game executable in the game directory (assuming the build was successful):**
@@ -117,7 +114,7 @@ to build the project from the command line.
 - **To build a specific target:**
   - Run `cmake --build build/<preset name> --target <target name>`
   - Example: `cmake --build build/win32dgb --target z_generals`
-  - Or: `cmake --build build/win32int --target g_generals`
+  - Or: `cmake --build build/win32prof --target g_generals`
 
 For more CMake options, see the [CMake Guide](cmake_guide).
 

--- a/SourceCode/Builds/build_with_msvc6.md
+++ b/SourceCode/Builds/build_with_msvc6.md
@@ -119,7 +119,6 @@ Run the following command based on the type of build you want to create:
 
 - `cmake --workflow --preset vc6` for a release build.
 - `cmake --workflow --preset vc6-debug` for a debug build.
-- `cmake --workflow --preset vc6-internal` for an internal build.
 - `cmake --workflow --preset vc6-profile` for a profile build.
 
 You will find a bunch of files in `build\vc6\<game name>` and a file called `generalszh.exe` or `generalsv.exe`.

--- a/SourceCode/Builds/cmake_guide.md
+++ b/SourceCode/Builds/cmake_guide.md
@@ -28,14 +28,14 @@ The **preset** defines the predefined build configuration. The available presets
 ### For Visual Studio 2022 or Ninja
 
 - `win32`: Release build.
-- `win32dgb`: Debug build.
-- `win32prof`: Profile build.
+- `win32-debug`: Debug build.
+- `win32-profile`: Profile build.
 
 ### For Visual Studio 6
 
 - `vc6`: Release build.
-- `vc6dgb`: Debug build.
-- `vc6prof`: Profile build.
+- `vc6-debug`: Debug build.
+- `vc6-profile`: Profile build.
 
 ### Usage
 
@@ -194,13 +194,13 @@ To build the Zero Hour code along with its tools in debug mode, use the followin
 
 ```bash
 # Step 1: Configure the build with a preset and additional options
-cmake --preset win32dgb -DGENZH_BUILD_ZEROHOUR=ON -DGENZH_BUILD_ZEROHOUR_TOOLS=ON
+cmake --preset win32-debug -DGENZH_BUILD_ZEROHOUR=ON -DGENZH_BUILD_ZEROHOUR_TOOLS=ON
 
 # Step 2: Build the project
-cmake --build build/win32dbg
+cmake --build build/win32-debug
 
 # Step 3: Install the project to the default installation path
-cmake --install build/win32dbg
+cmake --install build/win32-debug
 ```
 <!-- markdownlint-disable-next-line -->
 ### **Build Only World Builder Tool:**

--- a/SourceCode/Builds/cmake_guide.md
+++ b/SourceCode/Builds/cmake_guide.md
@@ -29,14 +29,12 @@ The **preset** defines the predefined build configuration. The available presets
 
 - `win32`: Release build.
 - `win32dgb`: Debug build.
-- `win32int`: Internal build.
 - `win32prof`: Profile build.
 
 ### For Visual Studio 6
 
 - `vc6`: Release build.
 - `vc6dgb`: Debug build.
-- `vc6int`: Internal build.
 - `vc6prof`: Profile build.
 
 ### Usage


### PR DESCRIPTION
- Merge after https://github.com/TheSuperHackers/GeneralsGameCode/pull/1231

This pull request does the following:

- Removes all mentions of the Internal CMake build profile, since it has been removed in TheSuperHackers/GeneralsGameCode#1231
- Updates all the remaining outdated Cmake build profile names to match the correct profile names.