### PR TITLE
Updated build guides for vc6 with cmake and clion with vc6. Also added notice about debug builds

### DIFF
--- a/SourceCode/Builds/build_configuration.md
+++ b/SourceCode/Builds/build_configuration.md
@@ -41,6 +41,17 @@ There are four main build configurations in the project, each designed for diffe
 
 - **Use Case:** Used during development for debugging and resolving issues in the code.
 
+> **⚠️ Debug Build Requirements:** To run a debug build of the game, you need to have  
+> the following two files in the game directory alongside the built executable:
+>
+> - [`MSVCRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Runtime Library (Debug)
+> - [`MSVCIRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Internationalization Runtime Library (Debug)
+>
+> These files are available from the [Community Outpost Discord server](https://discord.gg/WzxQDZersE) (links above  
+> are from the server) and may require a Discord account to download.
+
 ### 3. **Profile (O2, IG_DEBUG_STACKTRACE, _RELEASE, _PROFILE)**
 
 - **Purpose:** The profile configuration is used for performance profiling and optimization. It is designed to help

--- a/SourceCode/Builds/build_guides.md
+++ b/SourceCode/Builds/build_guides.md
@@ -19,6 +19,17 @@ Each configuration is designed for a different purpose, whether you're building 
 releasing the final product. You can find more details about the build configurations in
 the [Build Configurations](build_configuration) page.
 
+> **⚠️ Debug Build Requirements:** To run a debug build of the game, you need to have  
+> the following two files in the game directory alongside the built executable:
+>
+> - [`MSVCRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Runtime Library (Debug)
+> - [`MSVCIRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Internationalization Runtime Library (Debug)
+>
+> These files are available from the [Community Outpost Discord server](https://discord.gg/WzxQDZersE) (links above  
+> are from the server) and may require a Discord account to download.
+
 ## Architectures and Toolchains
 
 The project supports multiple architectures and toolchains, which is why there are various build guides tailored to

--- a/SourceCode/Builds/build_with_clion_vc6_toolchain.md
+++ b/SourceCode/Builds/build_with_clion_vc6_toolchain.md
@@ -7,15 +7,28 @@ compatibility with the original compiler from the game's development era. To com
 ## Prerequisites
 
 - [Visual Studio 6.0 Portable](https://github.com/itsmattkc/MSVC600)
+  > See the [Visual Studio 6.0 Portable installation instructions](build_with_msvc6.md#visual-studio-60-portable)
+  > for setup details.
 - [CLion](https://www.jetbrains.com/clion/)
-- [Source Code](https://github.com/TheSuperHackers/GeneralsGameCode) of the project cloned from the TheSuperHackers repository
 
 > For simplicity, this guide assumes the user will be using the
 > default install folder for Visual Studio 6.0 Portable: `C:\Program Files (x86)\Microsoft Visual Studio\`
 
-## Step 1: Setting Up the Toolchain in CLion
+## Step 1: Clone and Open the Project
 
-1. Open the cloned folder in **CLion** and go to **File** → **Settings** → **Build, Execution,
+1. Clone the source code from TheSuperHackers:
+
+   ```shell
+   git clone https://github.com/TheSuperHackers/GeneralsGameCode.git
+   ```
+
+   > Alternatively, you can clone the repository directly from within CLion.
+
+2. Open the cloned folder in **CLion**.
+
+## Step 2: Setting Up the Toolchain in CLion
+
+1. In CLion, go to **File** → **Settings** → **Build, Execution,
    Deployment** → **Toolchains**.
 2. Add a new **Toolchain** by clicking the **+** button.
 3. Select **System** as the type (not Visual Studio).
@@ -49,7 +62,7 @@ compatibility with the original compiler from the game's development era. To com
 
 ![CLion VC6 Toolchain Configuration](https://github.com/TheSuperHackers/GeneralsWiki/raw/refs/heads/main/SourceCode/Builds/files/clionvc6toolchain.png)
 
-## Step 2: Configuring the CMake Profiles
+## Step 3: Configuring the CMake Profiles
 
 1. In the CMake profiles, enable the profiles you want to use. The available workflow presets are:
    - `vc6` - Release build
@@ -58,7 +71,7 @@ compatibility with the original compiler from the game's development era. To com
 
    For detailed information about each build configuration and their specific purposes, see the [Build Configurations Overview](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_configuration).
 
-## Step 3: Configuring the Installation Path
+## Step 4: Configuring the Installation Path
 
 1. In the target application options, do the following:
 
@@ -69,12 +82,25 @@ compatibility with the original compiler from the game's development era. To com
    - To avoid duplicate builds, remove the **Build** step.
    - Save the configuration, and you are ready to build and run the project.
 
-## Step 4: Compiling and Running the Project
+## Step 5: Compiling and Running the Project
 
 1. Now, click the **Build** button in CLion, or click **Install** in the build menu.
 2. CLion will start the build/install process using the VC6 (x86) toolchain.
 3. Once the build is successfully completed, an executable file will be generated and installed in the
    game directory.
+
+## Running Debug Builds
+
+> **⚠️ Debug Build Requirements:** To run a debug build of the game, you need to have  
+> the following two files in the game directory alongside the built executable:
+>
+> - [`MSVCRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Runtime Library (Debug)
+> - [`MSVCIRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Internationalization Runtime Library (Debug)
+>
+> These files are available from the [Community Outpost Discord server](https://discord.gg/WzxQDZersE) (links above  
+> are from the server) and may require a Discord account to download.
 
 ## Notes
 

--- a/SourceCode/Builds/build_with_msvc6.md
+++ b/SourceCode/Builds/build_with_msvc6.md
@@ -17,37 +17,60 @@ Even if you do not know C++, you should still be able to compile the source code
 understanding of how C++ is compiled is necessary. This includes knowing what the **compiler** and
 **linker** do, as well as being able to interpret error messages and troubleshoot them effectively.
 
-## Prerequisites
+## Prerequisites and setting up the build environment
 
-Download the following binaries and software and have them ready in a project folder.
+Download and install the following tools and software needed for compilation.
 
-- [Visual Studio 6.0 Portable](https://github.com/itsmattkc/MSVC600)
-- [CMake 3.31.6](https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.msi) or [newer](https://cmake.org/download/#latest)
-- [Git](https://git-scm.com/downloads)
-
-> For simplicity, this guide will use the installers for Git and CMake and assumes the user will use the
+> **ℹ️ Setup Note:** For simplicity, this guide will use the installers for Git and CMake and assumes the user will use the
 default install folder for Visual Studio 6.0 Portable.
 
-## Installing your build environment
+### Visual Studio 6.0 Portable
 
-Installation of tools and software that are needed for compilation.
+**Download:** [Visual Studio 6.0 Portable](https://github.com/itsmattkc/MSVC600)
 
-### Install Visual Studio 6
+The original compiler used for game development.
 
-- Download the portable Visual Studio 6 as a ZIP file from GitHub.
-- Extract the common and VC98 folders from the downloaded archive to the default install folder.
+**Installation:**
+
+- Download the portable Visual Studio 6 as a ZIP file from GitHub
+- Extract the `common` and `VC98` folders from the downloaded archive to the default install folder
 - Default installation folder: `C:\Program Files (x86)\Microsoft Visual Studio\`
 
 > Alternatively, you can use the VC6 setup from Archive.org.
 
-### Install CMake
+### Git
 
-- Run the installer for CMake.
-- Enable the option to add CMake to the system path during the setup wizard.
+**Download:** [Git](https://git-scm.com/downloads)
 
-### Install Git
+Required for cloning the source code repository.
 
-- Run the Git installer.
+**Installation:**
+
+- Run the Git installer
+
+### CMake *(added to system path)*
+
+**Download:** [CMake 3.31.6](https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.msi)
+or [newer](https://cmake.org/download/#latest)
+
+> **Note:** Not required if using IDEs like CLion or Visual Studio 2022, as these include built-in CMake support.
+
+**Installation:**
+
+- Run the installer for CMake
+- Enable the option to add CMake to the system path during the setup wizard
+
+### Ninja *(added to system path)*
+
+**Download:** [Ninja](https://ninja-build.org/)
+
+> **Note:** Not required if using IDEs like CLion or Visual Studio 2022, as these include a bundled ninja binary.
+
+**Installation:**
+
+- Download the Ninja binary from the [Ninja releases page](https://ninja-build.org/)
+- Extract the `ninja.exe` file to a folder of your choice
+- Add the folder containing `ninja.exe` to your system's PATH environment variable
 
 ## Clone
 
@@ -117,9 +140,23 @@ set MSVCDir=C:\<VS6_INSTALL_PATH>\VC98
 
 Run the following command based on the type of build you want to create:
 
-- `cmake --workflow --preset vc6` for a release build.
-- `cmake --workflow --preset vc6-debug` for a debug build.
-- `cmake --workflow --preset vc6-profile` for a profile build.
+- For a release build:
+
+``` shell
+cmake --workflow --preset vc6
+```
+
+- For a debug build:
+
+``` shell
+cmake --workflow --preset vc6-debug
+```
+
+- For a profile build:
+
+``` shell
+cmake --workflow --preset vc6-profile
+```
 
 You will find a bunch of files in `build\vc6\<game name>` and a file called `generalszh.exe` or `generalsv.exe`.
 
@@ -127,8 +164,26 @@ For detailed information about each build configuration and their specific purpo
 
 ### Install the game executable
 
-Run ```cmake --install build\<vc6 build type>```, this will copy the executable to the retail game directory,
-or you can copy it manually.
+Run the following command to copy the executable to the retail game directory:
+
+``` shell
+cmake --install build\<vc6 build type>
+```
+
+Alternatively, you can copy it manually.
+
+### Running Debug Builds
+
+> **⚠️ Debug Build Requirements:** To run a debug build of the game, you need to copy  
+> the following two files into the game directory alongside the built executable:
+>
+> - [`MSVCRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Runtime Library (Debug)
+> - [`MSVCIRTD.DLL`](https://discord.com/channels/951133504605917224/1344671543170564176/1357087699982352426)  
+>   Microsoft Visual C++ Internationalization Runtime Library (Debug)
+>
+> These files are available from the [Community Outpost Discord server](https://discord.gg/WzxQDZersE) (links above  
+> are from the server) and may require a Discord account to download.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This pull request does the following:

- Updates the build guides for vc6 with cmake and clion with vc6 with various improvements and some clarifications.
- Adds Ninja as a prerequisite in the VC6 with CMake guide.
- Adds notices about running debug builds to several build related pages.