### PR TITLE
Refined CLion VC6 toolchain guide: clarify CMake profile setup and run/debug configurations

### DIFF
--- a/SourceCode/Builds/build_with_clion_vc6_toolchain.md
+++ b/SourceCode/Builds/build_with_clion_vc6_toolchain.md
@@ -11,8 +11,8 @@ compatibility with the original compiler from the game's development era. To com
   > for setup details.
 - [CLion](https://www.jetbrains.com/clion/)
 
-> For simplicity, this guide assumes the user will be using the
-> default install folder for Visual Studio 6.0 Portable: `C:\Program Files (x86)\Microsoft Visual Studio\`
+> This guide assumes the user uses the default installation
+> folder for Visual Studio 6.0 Portable: `C:\Program Files (x86)\Microsoft Visual Studio\`
 
 ## Step 1: Clone and Open the Project
 
@@ -64,29 +64,42 @@ compatibility with the original compiler from the game's development era. To com
 
 ## Step 3: Configuring the CMake Profiles
 
-1. In the CMake profiles, enable the profiles you want to use. The available workflow presets are:
-   - `vc6` - Release build
-   - `vc6-debug` - Debug build
-   - `vc6-profile` - Profile build
+1. To configure the CMake profiles, proceed with the following steps:
+   - Go to **File** → **Settings** → **Build, Execution, Deployment** → **CMake**.
+   (should open automatically after opening the folder containing the cloned source code)
+   - Disable the default `Debug` profile.
+   - Enable `vc6` - Release build
+   - Enable `vc6-debug` - Debug build
+   - Enable `vc6-profile` - Profile build
 
    For detailed information about each build configuration and their specific purposes, see the [Build Configurations Overview](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_configuration).
 
 ## Step 4: Configuring the Installation Path
 
-1. In the target application options, do the following:
+1. In the **Run/Debug Configurations** dropdown, select the target game: `z_generals` (Zero Hour) or `g_generals` (Generals).
+2. Open the same dropdown, then for the target game you just selected, click the 3 dots on the right, then **Edit...**
+
+   > **Note:** This step must be repeated for both `z_generals` and `g_generals` targets.
 
    - Set **Program arguments** with your preferred command line arguments, such as `-win`, `-quickstart`, etc.
+   - Set **Executable** to the path of your game install plus the built executable name, for example:
+
+     ```text
+     C:\Program Files (x86)\Command & Conquer Generals Zero Hour\generalszh.exe (for Zero Hour) or
+     C:\Program Files (x86)\Command & Conquer Generals Zero Hour\generalsv.exe (for Generals)
+     ```
+
+     This ensures that the game starts correctly after clicking the run button in CLion.
+
    - Set **Working directory** to the game directory.
    - Check the **Run as administrator** option.
-   - In the **Before launch** section, add a new **install** step.
    - To avoid duplicate builds, remove the **Build** step.
+   - In the **Before launch** section, add a new **install** step.
    - Save the configuration, and you are ready to build and run the project.
 
 ## Step 5: Compiling and Running the Project
 
-1. Now, click the **Build** button in CLion, or click **Install** in the build menu.
-2. CLion will start the build/install process using the VC6 (x86) toolchain.
-3. Once the build is successfully completed, an executable file will be generated and installed in the
+   Click **Run** on the toolbar, or build the project and run the executable from the
    game directory.
 
 ## Running Debug Builds
@@ -103,7 +116,5 @@ compatibility with the original compiler from the game's development era. To com
 
 - Working with VC6 requires some adjustments, so it’s a good idea to verify
   that the toolchain is working properly.
-- You can add Release and Debug profiles in CLion to build the project in
-  different configurations.
 - Administrator rights may be required to run VC6 tools, so run CLion as an administrator if
   needed.


### PR DESCRIPTION
Apparently, you can also make the IDE launch the game directly, so the guide as been updated to reflect that.