### PR TITLE
fix dockerfile branch & move configration

### DIFF
--- a/SourceCode/Builds/build_with_msvc6_on_docker.md
+++ b/SourceCode/Builds/build_with_msvc6_on_docker.md
@@ -84,12 +84,9 @@ ENV CXX="$VS\\vc98\\bin\\CL.exe"
 # Clone the source code
 ENV GIT_VERSION_STRING="2.49.0"
 RUN git clone https://github.com/TheSuperHackers/GeneralsGameCode.git
-RUN mv /build/CnC_Generals_Zero_Hour /build/cnc
+RUN mv /build/GeneralsGameCode /build/cnc
 
 WORKDIR /build/cnc
-
-# Switch to WIP branch
-RUN git switch blade/cmake-build
 
 # Run cmake
 RUN wine /build/tools/cmake/bin/cmake.exe \


### PR DESCRIPTION
## Fix incorrect source directory and remove invalid branch selection

- Renamed the cloned GeneralsGameCode directory correctly to /build/cnc.
- Removed the invalid default branch selection.

