### PR TITLE
docs: Upgrade Docker guide to use Ninja

### DIFF
--- a/SourceCode/Builds/build_with_msvc6_on_docker.md
+++ b/SourceCode/Builds/build_with_msvc6_on_docker.md
@@ -123,5 +123,14 @@ CMD ["tail", "-f", "/dev/null"]
 Build the game by executing `docker build -t zerohour .`
 
 After the build you can run the container and use `docker cp`
-or you could mount a volume to `/build` so you can directly
+
+```bash
+# 1. Start the container in the background
+docker run -d --name zh_builder zerohour
+
+# 2. Copy the executable to your host machine
+docker cp zh_builder:/build/cnc/build/vc6/GeneralsMD .
+```
+
+Or you could mount a volume to `/build` so you can directly
 compile your own code and copy the binary off.


### PR DESCRIPTION
### Summary
Updates the `build_with_msvc6_on_docker.md` guide to utilize modern build tools and LTS package sources.

### Key Changes
1.  **Build System:** Switched from `NMake` to `Ninja`.
    * Downloads `ninja-win.zip`.
    * Configures CMake with `-G "Ninja"`.
    * *Benefit:* Enables multi-threaded compilation (much faster builds).
2.  **OS Compatibility:** Updated WineHQ apt sources to `noble` (Ubuntu 24.04) to ensure compatibility with the LTS base image.
3.  **Best Practices:** Converted `CMD` to exec form (`["tail", ...]`) for better process handling.