### PR TITLE
docs: Add Linux build guide with convenience scripts

### DIFF
--- a/SourceCode/Builds/build_guides.md
+++ b/SourceCode/Builds/build_guides.md
@@ -60,7 +60,7 @@ environments.
       [Build with CMake & Visual Studio 6 (x86) (Windows)](build_with_msvc6)
 
    #### Sub-guides
-  
+
     - **CLion & VC6 Toolchain**
         - A guide for using CLion with the Visual Studio 6 (VC6) toolchain for building the project.
          [Build with CLion & VC6 Toolchain](build_with_clion_vc6_toolchain)
@@ -68,6 +68,10 @@ environments.
         - A guide for setting up Docker with the Visual Studio 6 (VC6) toolchain for building the project in a
           containerized environment.
          [Build with Docker & VC6](build_with_msvc6_on_docker)
+    - **Build on Linux**
+        - A guide for building the project on Linux using Docker with convenience scripts.
+          Includes instructions for installing built executables to an existing game.
+         [Build on Linux](build_on_linux)
 
 ### **Visual Studio 2022 Guides**
 

--- a/SourceCode/Builds/build_on_linux.md
+++ b/SourceCode/Builds/build_on_linux.md
@@ -1,0 +1,207 @@
+# Build Command & Conquer Generals on Linux
+
+This guide covers building Generals and Zero Hour on Linux using Docker. The build produces Windows executables that can run natively on Windows or under Wine on Linux.
+
+## Quick Start
+
+The repository includes convenience scripts that automate the Docker build process:
+
+```bash
+# Clone the repository
+git clone https://github.com/TheSuperHackers/GeneralsGameCode.git
+cd GeneralsGameCode
+
+# Build using Docker (produces Windows executables)
+./scripts/build-linux.sh
+
+# Install to your game (auto-detects Wine prefix)
+./scripts/install-to-game.sh --detect
+```
+
+## Prerequisites
+
+- **Docker**: Install Docker Engine for your distribution
+  - [Debian/Ubuntu](https://docs.docker.com/engine/install/debian/)
+  - [Fedora](https://docs.docker.com/engine/install/fedora/)
+  - [Arch Linux](https://wiki.archlinux.org/title/Docker)
+- **Git**: For cloning the repository
+- **Wine** (optional): For running the built executables on Linux
+
+### Docker Setup
+
+Ensure Docker is running and your user has permission:
+
+```bash
+# Start Docker daemon
+sudo systemctl start docker
+
+# Add your user to the docker group (logout/login required)
+sudo usermod -aG docker $USER
+```
+
+## Build Scripts
+
+### build-linux.sh
+
+The main build script that manages the Docker-based build process.
+
+```bash
+# Full build (both Generals and Zero Hour)
+./scripts/build-linux.sh
+
+# Build Zero Hour only
+./scripts/build-linux.sh --game zh
+
+# Build Generals only
+./scripts/build-linux.sh --game generals
+
+# Build specific target
+./scripts/build-linux.sh --target generalszh
+
+# Clean build directory first
+./scripts/build-linux.sh --clean
+
+# Force CMake reconfiguration
+./scripts/build-linux.sh --cmake
+
+# Enter container shell for debugging
+./scripts/build-linux.sh --interactive
+```
+
+Build outputs are placed in `build/docker/`:
+
+| Directory | Contents |
+|-----------|----------|
+| `build/docker/GeneralsMD/` | Zero Hour executables |
+| `build/docker/Generals/` | Generals executables |
+| `build/docker/Core/` | Shared DLLs |
+
+### install-to-game.sh
+
+Installs built executables to an existing game installation.
+
+```bash
+# Auto-detect game location (checks Wine prefixes and common paths)
+./scripts/install-to-game.sh --detect
+
+# Specify game directory manually
+./scripts/install-to-game.sh ~/.wine/drive_c/Program\ Files/EA\ Games/Command\ and\ Conquer\ Generals\ Zero\ Hour
+
+# Install Generals instead of Zero Hour
+./scripts/install-to-game.sh --game generals /path/to/game
+
+# Dry run (show what would be installed)
+./scripts/install-to-game.sh --dry-run --detect
+
+# Restore original files from backups
+./scripts/install-to-game.sh --restore /path/to/game
+```
+
+The script will:
+1. Backup your original executables (`.exe.backup`)
+2. Copy newly built executables
+3. Copy new DLLs (DebugWindow.dll, ParticleEditor.dll)
+4. Preserve original mss32.dll and binkw32.dll (audio/video libraries)
+
+## Running the Game
+
+After building and installing, run the game with Wine:
+
+```bash
+# Zero Hour
+wine ~/.wine/drive_c/Program\ Files/EA\ Games/Command\ and\ Conquer\ Generals\ Zero\ Hour/Data/generalszh.exe
+
+# Or from the build directory (requires game data files)
+wine build/docker/GeneralsMD/generalszh.exe
+```
+
+### Wine Configuration
+
+For best results:
+
+```bash
+# Use 32-bit Wine prefix
+WINEARCH=win32 WINEPREFIX=~/.wine-generals winecfg
+
+# Set Windows version to Windows XP or Windows 7
+winecfg
+```
+
+## Troubleshooting
+
+### Docker Permission Denied
+
+```
+Got permission denied while trying to connect to the Docker daemon
+```
+
+Solution: Add your user to the docker group and re-login:
+```bash
+sudo usermod -aG docker $USER
+# Then logout and login again
+```
+
+### Build Directory Not Found
+
+```
+Build directory not found: /path/to/GeneralsGameCode/build/docker
+```
+
+Solution: Run the build script first:
+```bash
+./scripts/build-linux.sh
+```
+
+### Game Not Found
+
+```
+No game installation found
+```
+
+Solution: Specify the game directory manually:
+```bash
+./scripts/install-to-game.sh /path/to/your/game/installation
+```
+
+### Wine Errors
+
+If the game crashes or has graphical issues:
+
+1. Try different Wine versions (wine-staging often works better for games)
+2. Install required dependencies: `winetricks directx9 vcrun6`
+3. Use DXVK for better DirectX performance: `winetricks dxvk`
+
+## Manual Docker Build
+
+If you prefer to run the Docker commands manually instead of using the scripts:
+
+```bash
+# Build the Docker image
+docker build \
+    --build-arg UID=$(id -u) \
+    --build-arg GID=$(id -g) \
+    resources/dockerbuild \
+    -t zerohour-build
+
+# Run the build
+docker run \
+    -u $(id -u):$(id -g) \
+    -v $(pwd):/build/cnc \
+    --rm \
+    zerohour-build
+
+# Enter container for debugging
+docker run \
+    -u $(id -u):$(id -g) \
+    -v $(pwd):/build/cnc \
+    --rm \
+    -it \
+    --entrypoint bash \
+    zerohour-build
+```
+
+## See Also
+
+- [Build with VC6 on Docker](build_with_msvc6_on_docker.md) - Manual Docker setup
+- [Build Configuration](build_configuration.md) - CMake presets and options
+- [Build Guides](build_guides.md) - All build guides

--- a/SourceCode/Builds/build_on_linux.md
+++ b/SourceCode/Builds/build_on_linux.md
@@ -1,6 +1,7 @@
 # Build Command & Conquer Generals on Linux
 
-This guide covers building Generals and Zero Hour on Linux using Docker. The build produces Windows executables that can run natively on Windows or under Wine on Linux.
+This guide covers building Generals and Zero Hour on Linux using Docker. The build produces Windows
+executables that can run natively on Windows or under Wine on Linux.
 
 ## Quick Start
 
@@ -70,11 +71,11 @@ The main build script that manages the Docker-based build process.
 
 Build outputs are placed in `build/docker/`:
 
-| Directory | Contents |
-|-----------|----------|
-| `build/docker/GeneralsMD/` | Zero Hour executables |
-| `build/docker/Generals/` | Generals executables |
-| `build/docker/Core/` | Shared DLLs |
+| Directory                   | Contents               |
+| --------------------------- | ---------------------- |
+| `build/docker/GeneralsMD/`  | Zero Hour executables  |
+| `build/docker/Generals/`    | Generals executables   |
+| `build/docker/Core/`        | Shared DLLs            |
 
 ### docker-install.sh
 
@@ -98,6 +99,7 @@ Installs built executables to an existing game installation.
 ```
 
 The script will:
+
 1. Backup your original executables (`.exe.backup`)
 2. Copy newly built executables
 3. Copy new DLLs (DebugWindow.dll, ParticleEditor.dll)
@@ -131,11 +133,12 @@ winecfg
 
 ### Docker Permission Denied
 
-```
+```text
 Got permission denied while trying to connect to the Docker daemon
 ```
 
 Solution: Add your user to the docker group and re-login:
+
 ```bash
 sudo usermod -aG docker $USER
 # Then logout and login again
@@ -143,22 +146,24 @@ sudo usermod -aG docker $USER
 
 ### Build Directory Not Found
 
-```
+```text
 Build directory not found: /path/to/GeneralsGameCode/build/docker
 ```
 
 Solution: Run the build script first:
+
 ```bash
 ./scripts/docker-build.sh
 ```
 
 ### Game Not Found
 
-```
+```text
 No game installation found
 ```
 
 Solution: Specify the game directory manually:
+
 ```bash
 ./scripts/docker-install.sh /path/to/your/game/installation
 ```

--- a/SourceCode/Builds/build_on_linux.md
+++ b/SourceCode/Builds/build_on_linux.md
@@ -85,7 +85,7 @@ Installs built executables to an existing game installation.
 ./scripts/docker-install.sh --detect
 
 # Specify game directory manually
-./scripts/docker-install.sh "$HOME/.wine/drive_c/Program Files/EA Games/Command and Conquer Generals Zero Hour"
+./scripts/docker-install.sh /path/to/game
 
 # Install Generals instead of Zero Hour
 ./scripts/docker-install.sh --game generals /path/to/game
@@ -108,8 +108,8 @@ The script will:
 After building and installing, run the game with Wine:
 
 ```bash
-# Zero Hour
-wine "$HOME/.wine/drive_c/Program Files/EA Games/Command and Conquer Generals Zero Hour/Data/generalszh.exe"
+# Zero Hour (path depends on your installation)
+wine /path/to/game/generalszh.exe
 
 # Or from the build directory (requires game data files)
 wine build/docker/GeneralsMD/generalszh.exe

--- a/SourceCode/Builds/build_on_linux.md
+++ b/SourceCode/Builds/build_on_linux.md
@@ -12,10 +12,10 @@ git clone https://github.com/TheSuperHackers/GeneralsGameCode.git
 cd GeneralsGameCode
 
 # Build using Docker (produces Windows executables)
-./scripts/build-linux.sh
+./scripts/docker-build.sh
 
 # Install to your game (auto-detects Wine prefix)
-./scripts/install-to-game.sh --detect
+./scripts/docker-install.sh --detect
 ```
 
 ## Prerequisites
@@ -41,31 +41,31 @@ sudo usermod -aG docker $USER
 
 ## Build Scripts
 
-### build-linux.sh
+### docker-build.sh
 
 The main build script that manages the Docker-based build process.
 
 ```bash
 # Full build (both Generals and Zero Hour)
-./scripts/build-linux.sh
+./scripts/docker-build.sh
 
 # Build Zero Hour only
-./scripts/build-linux.sh --game zh
+./scripts/docker-build.sh --game zh
 
 # Build Generals only
-./scripts/build-linux.sh --game generals
+./scripts/docker-build.sh --game generals
 
 # Build specific target
-./scripts/build-linux.sh --target generalszh
+./scripts/docker-build.sh --target generalszh
 
 # Clean build directory first
-./scripts/build-linux.sh --clean
+./scripts/docker-build.sh --clean
 
 # Force CMake reconfiguration
-./scripts/build-linux.sh --cmake
+./scripts/docker-build.sh --cmake
 
 # Enter container shell for debugging
-./scripts/build-linux.sh --interactive
+./scripts/docker-build.sh --interactive
 ```
 
 Build outputs are placed in `build/docker/`:
@@ -76,25 +76,25 @@ Build outputs are placed in `build/docker/`:
 | `build/docker/Generals/` | Generals executables |
 | `build/docker/Core/` | Shared DLLs |
 
-### install-to-game.sh
+### docker-install.sh
 
 Installs built executables to an existing game installation.
 
 ```bash
 # Auto-detect game location (checks Wine prefixes and common paths)
-./scripts/install-to-game.sh --detect
+./scripts/docker-install.sh --detect
 
 # Specify game directory manually
-./scripts/install-to-game.sh ~/.wine/drive_c/Program\ Files/EA\ Games/Command\ and\ Conquer\ Generals\ Zero\ Hour
+./scripts/docker-install.sh "$HOME/.wine/drive_c/Program Files/EA Games/Command and Conquer Generals Zero Hour"
 
 # Install Generals instead of Zero Hour
-./scripts/install-to-game.sh --game generals /path/to/game
+./scripts/docker-install.sh --game generals /path/to/game
 
 # Dry run (show what would be installed)
-./scripts/install-to-game.sh --dry-run --detect
+./scripts/docker-install.sh --dry-run --detect
 
 # Restore original files from backups
-./scripts/install-to-game.sh --restore /path/to/game
+./scripts/docker-install.sh --restore /path/to/game
 ```
 
 The script will:
@@ -109,7 +109,7 @@ After building and installing, run the game with Wine:
 
 ```bash
 # Zero Hour
-wine ~/.wine/drive_c/Program\ Files/EA\ Games/Command\ and\ Conquer\ Generals\ Zero\ Hour/Data/generalszh.exe
+wine "$HOME/.wine/drive_c/Program Files/EA Games/Command and Conquer Generals Zero Hour/Data/generalszh.exe"
 
 # Or from the build directory (requires game data files)
 wine build/docker/GeneralsMD/generalszh.exe
@@ -149,7 +149,7 @@ Build directory not found: /path/to/GeneralsGameCode/build/docker
 
 Solution: Run the build script first:
 ```bash
-./scripts/build-linux.sh
+./scripts/docker-build.sh
 ```
 
 ### Game Not Found
@@ -160,7 +160,7 @@ No game installation found
 
 Solution: Specify the game directory manually:
 ```bash
-./scripts/install-to-game.sh /path/to/your/game/installation
+./scripts/docker-install.sh /path/to/your/game/installation
 ```
 
 ### Wine Errors


### PR DESCRIPTION
## Summary

Add comprehensive documentation for building on Linux using the convenience scripts from PR TheSuperHackers/GeneralsGameCode#2085.

## Changes

| File | Description |
|------|-------------|
| `SourceCode/Builds/build_on_linux.md` | New comprehensive Linux build guide |
| `SourceCode/Builds/build_guides.md` | Add link to new guide |

## New Guide Contents

- Quick start with `build-linux.sh` and `install-to-game.sh` scripts
- Prerequisites (Docker, Git, Wine)
- Detailed script usage and options
- Running the game under Wine
- Troubleshooting common issues
- Manual Docker commands for advanced users

## Related

- GeneralsGameCode PR: TheSuperHackers/GeneralsGameCode#2085 (adds the scripts)